### PR TITLE
Enable non-HLS (progressive) video sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Audio & Video player in Flutter. This plugin provides audio/video playback with 
 support and lock screen controls for both iOS & Android. Also provides player events such as onPlay, 
 onPause, onTime etc. See example for more details.
 
-- Video supports **HLS** and **Progressive Steaming** for both iOS & Android with multi-audio support.
+* Video supports **HLS** and **Progressive Steaming** for both iOS & Android with multi-audio support.
 
 * Audio supports playback from URL only.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Audio & Video player in Flutter. This plugin provides audio/video playback with 
 support and lock screen controls for both iOS & Android. Also provides player events such as onPlay, 
 onPause, onTime etc. See example for more details.
 
-* Video only supports **HLS** at the moment for both iOS & Android with multi-audio support.
+- Video supports **HLS** and **Progressive Steaming** for both iOS & Android with multi-audio support.
 
 * Audio supports playback from URL only.
 


### PR DESCRIPTION
Added progressive streaming media source for Android.
There was no need to do the same on iOS as AVAsset does that for you.