### PR TITLE
Fixed change media on iOS and Android

### DIFF
--- a/android/src/main/kotlin/tv/mta/flutter_playout/video/PlayerLayout.java
+++ b/android/src/main/kotlin/tv/mta/flutter_playout/video/PlayerLayout.java
@@ -481,13 +481,13 @@ public class PlayerLayout extends PlayerView implements FlutterAVPlayer, EventCh
 
         try {
 
-            JSONObject args = (JSONObject) arguments;
+            java.util.HashMap<String, String> args = (java.util.HashMap<String, String>) arguments;
 
-            this.url = args.getString("url");
+            this.url = args.get("url");
 
-            this.title = args.getString("title");
+            this.title = args.get("title");
 
-            this.subtitle = args.getString("description");
+            this.subtitle = args.get("description");
 
             /* Produces DataSource instances through which media data is loaded. */
             DataSource.Factory dataSourceFactory = new DefaultDataSourceFactory(context,

--- a/lib/video.dart
+++ b/lib/video.dart
@@ -226,6 +226,7 @@ class _VideoState extends State<Video> {
         "title": widget.title,
         "subtitle": widget.subtitle,
         "isLiveStream": widget.isLiveStream,
+        "showControls": widget.showControls,
       });
     }
   }


### PR DESCRIPTION
- Fixed wrong arguments casting in Android PlayerLayout.
It was throwing exception and the change wouldn't happen.

- Fixed crash on iOS when attempting to change media.
It was crashing due to force unwrapping a non existing value (showControls).